### PR TITLE
fix unsignificant typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ PLUMED should compile with MPI active. Then download and patch GROMACS 2023
 wget https://ftp.gromacs.org/gromacs/gromacs-2023.tar.gz
 tar -xf gromacs-2023.tar.gz
 cd gromacs-2023
-mv ../gromacs-2023.tar.gz/ ./
+mv ../gromacs-2023.tar.gz ./
 plumed patch -p
 ```
 Select the GROMACS 2023 patch when prompted by PLUMED and install GROMACS


### PR DESCRIPTION
mv ../gromacs-2023.tar.gz/ ./ complains if the "/" is there.